### PR TITLE
Use AutoHotKey for Windows

### DIFF
--- a/latex_input/__main__.py
+++ b/latex_input/__main__.py
@@ -97,7 +97,10 @@ def input_thread():
                 break
 
             listened_text += text
-            translation = latex_to_unicode(listened_text)
+            translation = latex_to_unicode(
+                listened_text,
+                FontContext(formatting=FontVariantType.ITALIC if is_math_mode else 0)
+            )
 
             if translation:
                 translated_text = translation
@@ -122,38 +125,6 @@ def set_icon_state(activated: bool):
         tray_icon.setIcon(QtGui.QIcon(
             APP_ACTIVATED_ICON_FILE if activated else APP_ICON_FILE
         ))
-
-
-def accept_callback(text):
-    # Continue listening, there was no data to translate
-    # if len(listened_text) == 0 or listened_text == " ":
-    #     activate_listener()
-    #     return
-
-    translated_text = latex_to_unicode(
-        text,
-        FontContext(formatting=FontVariantType.ITALIC if is_math_mode else 0)
-    )
-
-    # Restart the listener with the original text if the translation failed
-    # Could be the user is still entering text that would make the translation work
-    # ie. `\mathbb{e asy}' fails at `\mathbb{e' but succeeds when complete.
-    if not translated_text:
-        print(f"Failed conversion, re-listening with text '{text}'")
-        # activate_listener(listened_text)
-        return
-
-    # Press backspace to delete the entered LaTeX
-    num_backspace = len(text) + 1  # +1 for space character
-    write_with_delay("\b" * num_backspace, delay=use_key_delay * KEYPRESS_DELAY)
-
-    print(f"Writing: '{translated_text}'")
-    write_with_delay(translated_text, delay=use_key_delay * KEYPRESS_DELAY)
-
-    # Continue listening
-    # HACK: The call_later is to fix consecutive `accept_callback`s from picking up
-    # the <space> from the previous call.
-    # keyboard.call_later(activate_listener)
 
 
 def write_with_delay(text: str, delay: float):

--- a/latex_input/__main__.py
+++ b/latex_input/__main__.py
@@ -3,9 +3,14 @@ import threading
 from typing import Final
 from PyQt5 import QtGui, QtWidgets, QtCore
 import keyboard
+import os
 import sys
 import time
-from latex_input.input_client_win import InputClient
+
+if os.name == "nt":
+    from latex_input.input_client_win import InputClient
+else:
+    from latex_input.input_client_generic import InputClient
 
 from latex_input.latex_converter import latex_to_unicode, FontContext
 from latex_input.parse_unicode_data import FontVariantType
@@ -20,7 +25,7 @@ TEXT_EDIT_FONTSIZE: Final[int] = 12
 # them at all.
 KEYPRESS_DELAY: Final[float] = 0.002
 
-tray_icon: QtWidgets.QSystemTrayIcon
+tray_icon: QtWidgets.QSystemTrayIcon = None
 use_key_delay = True
 is_math_mode = False
 

--- a/latex_input/client_win.py
+++ b/latex_input/client_win.py
@@ -1,0 +1,80 @@
+import ahk
+import atexit
+
+ahk_wait_activation = r"""
+#NoTrayIcon
+CapsLock & s::
+ExitApp
+return
+"""
+
+ahk_listen_script = r"""
+#NoTrayIcon
+SendDeactivation()
+{
+    FileAppend, Chr(16)Chr(3), *, UTF-8  ; Send a special code to indicate the input was cancelled
+}
+
+Input, value, V, {Space}{Tab}{Esc}{LControl}{RControl}{LAlt}{RAlt}{LWin}{RWin}{AppsKey}{F1}{F2}{F3}{F4}{F5}{F6}{F7}{F8}{F9}{F10}{F11}{F12}{Left}{Right}{Up}{Down}{Home}{End}{PgUp}{PgDn}{Del}{Ins}{NumLock}{PrintScreen}{Pause}
+
+; New Input has been started, cancel this one
+if (ErrorLevel = "NewInput")
+{
+    SendDeactivation()
+    ExitApp
+}
+
+; If any end key was pressed other than space or tab, cancel the operation
+if (ErrorLevel != "EndKey:Space" and ErrorLevel != "EndKey:Tab")
+{
+    SendDeactivation()
+    ExitApp
+}
+
+FileAppend, %value%, *, UTF-8  ; Print to stdout for Python to read
+
+ExitApp
+"""
+
+
+class Client():
+    def __init__(self, on_accept=None, on_activate=None, on_deactivate=None):
+        self.ahk = ahk.AHK()
+        self.on_accept = on_accept
+        self.on_activate = on_activate
+        self.on_deactivate = on_deactivate
+        self.proc = None
+
+    def run(self):
+        # Special handling to kill any dangling AutoHotKey process when this
+        # thread gets killed
+        def kill_proc():
+            if self.proc:
+                self.proc.kill()
+
+        atexit.register(kill_proc)
+
+        while True:
+            self._do_script(ahk_wait_activation)
+
+            if self.on_activate:
+                self.on_activate()
+
+            result = self._do_script(ahk_listen_script)
+
+            # Data Link Escape + End of Text
+            if result == b"\x10\x03":
+                if self.on_deactivate:
+                    self.on_deactivate()
+            else:
+                print(f"Received data: {result}")
+                if self.on_deactivate:
+                    self.on_deactivate()
+
+    def _do_script(self, script: str) -> str:
+        # We choose blocking=False to get a Popen instance, then block
+        # on it exiting anyways.
+        self.proc = self.ahk.run_script(script, blocking=False)
+        out, err = self.proc.communicate()
+
+        return out

--- a/latex_input/input_client_generic.py
+++ b/latex_input/input_client_generic.py
@@ -1,0 +1,45 @@
+import keyboard
+from queue import Queue
+
+
+class InputClient:
+    def __init__(self):
+        self.key_log = ""
+        self.queue = Queue(1)
+
+    def wait_for_hotkey(self):
+        # Generic disadvantage: Completely disables capslock
+        keyboard.block_key("capslock")
+        keyboard.wait('capslock+s', suppress=True, trigger_on_release=True)
+
+    def listen(self) -> str | None:
+        keyboard.hook(self._hook_callback)
+
+        text = self.queue.get()
+
+        keyboard.unhook(self._hook_callback)
+        self.key_log = ""
+
+        return text
+
+    def _hook_callback(self, event: keyboard.KeyboardEvent):
+        if event.event_type != keyboard.KEY_DOWN:
+            return
+
+        # Cancel characters
+        if any(substring in event.name
+                for substring in ["alt", "ctrl", "shift", "esc", "enter",
+                                  "left", "right", "up", "down"]):
+            self.queue.put(None)
+            self.key_log = ""
+
+        # Activation character
+        elif event.name == "space":
+            self.queue.put(self.key_log)
+            self.key_log = ""
+
+        elif event.name == "backspace":
+            if self.key_log:
+                self.key_log = self.key_log[:-1]
+        else:
+            self.key_log += event.name

--- a/latex_input/input_client_win.py
+++ b/latex_input/input_client_win.py
@@ -4,9 +4,9 @@ import atexit
 ahk_wait_activation = r"""
 #NoTrayIcon
 CapsLock & s::
-    ; Wait for CapsLock to be released
-    ; Otherwise this script exits before it can toggle CapsLock back off
-    KeyWait, CapsLock
+    ; This script exits before it can toggle CapsLock back
+    ; So we manually toggle it to its original state
+    SetCapsLockState % !GetKeyState("CapsLock", "T")
     ExitApp
 return
 """

--- a/latex_input/input_client_win.py
+++ b/latex_input/input_client_win.py
@@ -42,7 +42,7 @@ ExitApp
 """
 
 
-class InputClient():
+class InputClient:
     def __init__(self):
         self.ahk = ahk.AHK()
         self.proc = None

--- a/latex_input/input_client_win.py
+++ b/latex_input/input_client_win.py
@@ -1,4 +1,3 @@
-from typing import NoReturn
 import ahk
 import atexit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyQt5==5.15.7
+ahk==0.14.1
+ahk-binary==1.1.33.9
+keyboard==0.13.5


### PR DESCRIPTION
Fixes #11.
On Windows, the `keyboard` library's input hooks fail after the computer goes to sleep and wakes up.  
This change uses the `ahk` library on Windows to execute AutoHotKey code that doesn't have that issue.